### PR TITLE
VRK-59/fix-billboarding-bug

### DIFF
--- a/final-project/Assets/Scripts/LaserManager.cs
+++ b/final-project/Assets/Scripts/LaserManager.cs
@@ -271,7 +271,15 @@ public class LaserManager : MonoBehaviour
     // creates a TMP object as a child of ray at position
     void DrawAngle(GameObject parentRay, Vector3 position, float angle)
     {
-        GameObject camera = GameObject.FindGameObjectWithTag("MainCamera");
+        GameObject[] cameras = GameObject.FindGameObjectsWithTag("MainCamera"); // we have 2 AR cameras (Freeplay, Levels)
+        GameObject camera = cameras[0];
+        foreach (GameObject cam in cameras)
+        {
+            if ((Math.Abs(cam.transform.rotation.x) + Math.Abs(cam.transform.rotation.y) + Math.Abs(cam.transform.rotation.z))  > 0) // the inactive AR camera will have Rotation(0.0, 0.0, 0.0, 1.0), if both are the same, doesnt matter which we use.
+            {
+                camera = cam;
+            }
+        }
         position = position + new Vector3(0.5f, 0, 0);
         TextMeshPro ang =
             Instantiate(TextPrefab, position, camera.transform.rotation);

--- a/final-project/ProjectSettings/ProjectSettings.asset
+++ b/final-project/ProjectSettings/ProjectSettings.asset
@@ -129,8 +129,8 @@ PlayerSettings:
     Others: 1
   bundleVersion: 0.1
   preloadedAssets:
-  - {fileID: 6615093173677015987, guid: 7f2e28914307044bbb0b8dac172ec940, type: 2}
-  - {fileID: 4800000, guid: c9f956787b1d945e7b36e0516201fc76, type: 3}
+  - {fileID: 4800000, guid: e7c77f6eaab324a819efdc13b8125a39, type: 3}
+  - {fileID: 8852828353427850393, guid: 7f2e28914307044bbb0b8dac172ec940, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
**Cause of Bug**:
We now have multiple ARSession GameObjects, so `GameObject.getObjectWithTag("MainCamera")` now only fetches us the first instance, which is always the Freeplay ARSession, so in Levels, we are still getting the Freeplay ARSession, which because is inactive, is set to Rotation(0,0,0,0). 

**Solution**:
Get all cameras and check their rotations. If rotation is non-zero, we billboard according to that camera.